### PR TITLE
[FEAT] 카카오 로그인, 로그아웃, 리프레시 토큰 재발급 API구현

### DIFF
--- a/src/main/java/boosters/fundboost/global/config/WebConfig.java
+++ b/src/main/java/boosters/fundboost/global/config/WebConfig.java
@@ -1,13 +1,21 @@
 package boosters.fundboost.global.config;
 
+import boosters.fundboost.global.security.handler.resolver.AuthUserArgumentResolver;
+import boosters.fundboost.global.security.handler.resolver.TokenArgumentResolver;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.util.List;
 
 @Configuration
 @RequiredArgsConstructor
 public class WebConfig implements WebMvcConfigurer {
+    private final AuthUserArgumentResolver authUserArgumentResolver;
+    private final TokenArgumentResolver tokenArgumentResolver;
+
     @Override
     public void addCorsMappings(CorsRegistry registry) {
         registry.addMapping("/**")
@@ -16,5 +24,11 @@ public class WebConfig implements WebMvcConfigurer {
                 .allowedHeaders("*")
                 .allowCredentials(false)
                 .maxAge(6000);
+    }
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(authUserArgumentResolver);
+        resolvers.add(tokenArgumentResolver);
     }
 }

--- a/src/main/java/boosters/fundboost/global/redis/service/RefreshTokenService.java
+++ b/src/main/java/boosters/fundboost/global/redis/service/RefreshTokenService.java
@@ -1,0 +1,48 @@
+package boosters.fundboost.global.redis.service;
+
+import boosters.fundboost.global.redis.RefreshToken;
+import boosters.fundboost.global.redis.exception.TokenException;
+import boosters.fundboost.global.redis.repository.RefreshTokenRepository;
+import boosters.fundboost.global.response.code.status.ErrorStatus;
+import boosters.fundboost.global.security.jwt.JwtTokenProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class RefreshTokenService {
+    private final RefreshTokenRepository refreshTokenRepository;
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @Transactional(readOnly = true)
+    public boolean isEqualsToken(String refreshToken) {
+        RefreshToken savedRefreshToken =
+                refreshTokenRepository
+                        .findById(jwtTokenProvider.getId(refreshToken))
+                        .orElseThrow(() -> new TokenException(ErrorStatus.NOT_FOUND_TOKEN));
+        return savedRefreshToken.getToken().equals(refreshToken);
+    }
+
+    @Transactional
+    public void saveToken(String refreshToken) {
+        RefreshToken newRefreshToken =
+                refreshTokenRepository.save(
+                        RefreshToken.builder()
+                                .id(jwtTokenProvider.getId(refreshToken))
+                                .token(refreshToken)
+                                .build());
+        refreshTokenRepository.save(newRefreshToken);
+    }
+
+    @Transactional
+    public void deleteToken(Long userId) {
+        RefreshToken refreshToken =
+                refreshTokenRepository
+                        .findById(userId)
+                        .orElseThrow(() -> new TokenException(ErrorStatus.NOT_FOUND_TOKEN));
+
+        refreshTokenRepository.delete(refreshToken);
+    }
+}
+

--- a/src/main/java/boosters/fundboost/global/response/BaseResponse.java
+++ b/src/main/java/boosters/fundboost/global/response/BaseResponse.java
@@ -25,7 +25,7 @@ public class BaseResponse<T> {
     @JsonInclude(JsonInclude.Include.NON_NULL)
     private T result;
 
-    public static <T> BaseResponse<T> onSuccess(T data, SuccessStatus status) {
+    public static <T> BaseResponse<T> onSuccess(SuccessStatus status, T data) {
         return new BaseResponse<>(true, status.getCode(), status.getMessage(), data);
     }
 

--- a/src/main/java/boosters/fundboost/global/response/code/status/ErrorStatus.java
+++ b/src/main/java/boosters/fundboost/global/response/code/status/ErrorStatus.java
@@ -20,6 +20,8 @@ public enum ErrorStatus implements BaseErrorCode {
     NOT_FOUND_TOKEN(HttpStatus.NOT_FOUND, "TOKEN400", "토큰을 찾을 수 없습니다."),
     NOT_EQUAL_TOKEN(HttpStatus.BAD_REQUEST, "TOKEN401","토큰이 일치하지 않습니다."),
     INVALID_TOKEN(HttpStatus.BAD_REQUEST, "TOKEN402","유효하지 않은 토큰입니다."),
+    //USER
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "USER400", "유저를 찾을 수 없습니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/boosters/fundboost/global/security/handler/annotation/AuthToken.java
+++ b/src/main/java/boosters/fundboost/global/security/handler/annotation/AuthToken.java
@@ -1,0 +1,11 @@
+package boosters.fundboost.global.security.handler.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.PARAMETER)
+public @interface AuthToken {
+}

--- a/src/main/java/boosters/fundboost/global/security/handler/annotation/AuthUser.java
+++ b/src/main/java/boosters/fundboost/global/security/handler/annotation/AuthUser.java
@@ -1,0 +1,10 @@
+package boosters.fundboost.global.security.handler.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.PARAMETER)
+public @interface AuthUser {}

--- a/src/main/java/boosters/fundboost/global/security/handler/resolver/AuthUserArgumentResolver.java
+++ b/src/main/java/boosters/fundboost/global/security/handler/resolver/AuthUserArgumentResolver.java
@@ -1,0 +1,56 @@
+package boosters.fundboost.global.security.handler.resolver;
+
+import boosters.fundboost.global.response.code.status.ErrorStatus;
+import boosters.fundboost.global.security.handler.annotation.AuthUser;
+import boosters.fundboost.user.auth.exception.AuthException;
+import boosters.fundboost.user.domain.User;
+import boosters.fundboost.user.exception.UserException;
+import boosters.fundboost.user.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.MethodParameter;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+@Component
+@RequiredArgsConstructor
+public class AuthUserArgumentResolver implements HandlerMethodArgumentResolver {
+    private final UserService userService;
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.getParameterType().equals(User.class)
+                && parameter.hasParameterAnnotation(AuthUser.class);
+    }
+
+    @Override
+    public Object resolveArgument(
+            MethodParameter parameter,
+            ModelAndViewContainer mavContainer,
+            NativeWebRequest webRequest,
+            WebDataBinderFactory binderFactory) throws AuthException {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        Object principal = null;
+
+        if (authentication != null) {
+            if (authentication.getName().equals("anonymousUser")) {
+                throw new AuthException(ErrorStatus._BAD_REQUEST);
+            }
+            principal = authentication.getPrincipal();
+        }
+        if (principal == null || principal.getClass() == String.class) {
+            throw new UserException(ErrorStatus.USER_NOT_FOUND);
+        }
+        UsernamePasswordAuthenticationToken authenticationToken =
+                (UsernamePasswordAuthenticationToken) authentication;
+
+        Long userId = Long.valueOf(authenticationToken.getName());
+
+        return userService.getUser(userId);
+    }
+}

--- a/src/main/java/boosters/fundboost/global/security/handler/resolver/TokenArgumentResolver.java
+++ b/src/main/java/boosters/fundboost/global/security/handler/resolver/TokenArgumentResolver.java
@@ -1,0 +1,36 @@
+package boosters.fundboost.global.security.handler.resolver;
+
+import boosters.fundboost.global.security.handler.annotation.AuthToken;
+import boosters.fundboost.global.security.jwt.JwtTokenProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.MethodParameter;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+@Component
+@RequiredArgsConstructor
+public class TokenArgumentResolver implements HandlerMethodArgumentResolver {
+
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.getParameterType().equals(String.class)
+                && parameter.hasParameterAnnotation(AuthToken.class);
+    }
+
+    @Override
+    public Object resolveArgument(
+            MethodParameter parameter,
+            ModelAndViewContainer mavContainer,
+            NativeWebRequest webRequest,
+            WebDataBinderFactory binderFactory) {
+
+        String refreshToken = webRequest.getHeader("Authorization");
+        jwtTokenProvider.validateToken(refreshToken);
+        return refreshToken;
+    }
+}

--- a/src/main/java/boosters/fundboost/global/security/provider/KakaoAuthProvider.java
+++ b/src/main/java/boosters/fundboost/global/security/provider/KakaoAuthProvider.java
@@ -1,0 +1,85 @@
+package boosters.fundboost.global.security.provider;
+
+import boosters.fundboost.global.response.code.status.ErrorStatus;
+import boosters.fundboost.user.auth.dto.AuthResponse.KakaoOAuthToken;
+import boosters.fundboost.user.auth.dto.KakaoProfile;
+import boosters.fundboost.user.auth.exception.AuthException;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+
+@Component
+public class KakaoAuthProvider {
+    @Value("${kakao.client}")
+    private String client;
+
+    @Value("${kakao.redirect-uri}")
+    private String redirect;
+
+    public KakaoOAuthToken getAccessToken(String code) {
+        RestTemplate restTemplate = new RestTemplate();
+        HttpHeaders headers = new HttpHeaders();
+
+        headers.add("Content-type", "application/x-www-form-urlencoded;charset=utf-8");
+        MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+        params.add("grant_type", "authorization_code");
+        params.add("client_id", client);
+        params.add("redirect_uri", redirect);
+        params.add("code", code);
+
+        HttpEntity<MultiValueMap<String, String>> kakaoTokenRequest =
+                new HttpEntity<>(params, headers);
+        ResponseEntity<String> response =
+                restTemplate.exchange(
+                        "https://kauth.kakao.com/oauth/token",
+                        HttpMethod.POST,
+                        kakaoTokenRequest,
+                        String.class);
+
+        ObjectMapper objectMapper = new ObjectMapper();
+        KakaoOAuthToken oAuthToken;
+
+        try {
+            oAuthToken = objectMapper.readValue(response.getBody(), KakaoOAuthToken.class);
+        } catch (JsonProcessingException e) {
+            throw new AuthException(ErrorStatus.INVALID_REQUEST_INFO);
+        }
+
+        return oAuthToken;
+    }
+
+    public KakaoProfile getKakaoProfile(String token) {
+        RestTemplate restTemplate = new RestTemplate();
+        HttpHeaders headers = new HttpHeaders();
+        headers.add("Content-type", "application/x-www-form-urlencoded;charset=utf-8");
+        headers.add("Authorization", "Bearer " + token);
+
+        HttpEntity<MultiValueMap<String, String>> ProfileRequest = new HttpEntity<>(headers);
+
+        ResponseEntity<String> response =
+                restTemplate.exchange(
+                        "https://kapi.kakao.com/v2/user/me",
+                        HttpMethod.POST,
+                        ProfileRequest,
+                        String.class);
+
+        ObjectMapper objectMapper = new ObjectMapper();
+
+        KakaoProfile kakaoProfile;
+        try {
+            kakaoProfile = objectMapper.readValue(response.getBody(), KakaoProfile.class);
+        } catch (JsonProcessingException e) {
+            throw new AuthException(ErrorStatus.INVALID_REQUEST_INFO);
+        }
+
+        return kakaoProfile;
+    }
+}

--- a/src/main/java/boosters/fundboost/user/auth/controller/AuthController.java
+++ b/src/main/java/boosters/fundboost/user/auth/controller/AuthController.java
@@ -3,7 +3,9 @@ package boosters.fundboost.user.auth.controller;
 import boosters.fundboost.global.response.BaseResponse;
 import boosters.fundboost.global.response.code.status.SuccessStatus;
 import boosters.fundboost.global.security.handler.annotation.AuthUser;
+import boosters.fundboost.global.security.handler.annotation.AuthToken;
 import boosters.fundboost.user.auth.dto.AuthResponse.OAuthResponse;
+import boosters.fundboost.user.auth.dto.AuthResponse.TokenRefreshResponse;
 import boosters.fundboost.user.auth.service.AuthService;
 import boosters.fundboost.user.domain.User;
 import io.swagger.v3.oas.annotations.Operation;
@@ -14,6 +16,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -45,5 +48,16 @@ public class AuthController {
     public BaseResponse<Long> kakaoLogout(@Parameter(name = "user", hidden = true) @AuthUser User user) {
         authService.kakaoLogout(user.getId());
         return BaseResponse.onSuccess(SuccessStatus._OK, user.getId());
+    }
+
+    @Operation(summary = "토큰 재발급 API", description = "리프레시 토큰을 검증하고 토큰을 재발급 합니다._숙희")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
+            @ApiResponse(responseCode = "TOKEN400", description = "NOT_FOUND_TOKEN, 토큰을 찾을 수 없습니다."),
+            @ApiResponse(responseCode = "TOKEN402", description = "INVALID_TOKEN, 유효하지 않은 토큰입니다."),
+    })
+    @PostMapping("/kakao/refresh")
+    public BaseResponse<TokenRefreshResponse> refresh(@AuthToken String refreshToken) {
+        return BaseResponse.onSuccess(SuccessStatus._OK, authService.refresh(refreshToken));
     }
 }

--- a/src/main/java/boosters/fundboost/user/auth/controller/AuthController.java
+++ b/src/main/java/boosters/fundboost/user/auth/controller/AuthController.java
@@ -1,0 +1,49 @@
+package boosters.fundboost.user.auth.controller;
+
+import boosters.fundboost.global.response.BaseResponse;
+import boosters.fundboost.global.response.code.status.SuccessStatus;
+import boosters.fundboost.global.security.handler.annotation.AuthUser;
+import boosters.fundboost.user.auth.dto.AuthResponse.OAuthResponse;
+import boosters.fundboost.user.auth.service.AuthService;
+import boosters.fundboost.user.domain.User;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/auth")
+@Tag(name = "Auth 🔒", description = "인증 관련 API")
+public class AuthController {
+    private final AuthService authService;
+
+    @Operation(summary = "카카오 로그인 API", description = "인가코드를 받아 카카오 로그인 합니다._숙희")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
+            @ApiResponse(responseCode = "AUTH400", description = "INVALID_REQUEST_INFO, 잘못된 요청입니다."),
+            @ApiResponse(responseCode = "TOKEN400", description = "NOT_FOUND_TOKEN, 토큰을 찾을 수 없습니다."),
+    })
+    @GetMapping("/kakao/login")
+    public BaseResponse<OAuthResponse> kakaoLogin(@RequestParam("code") String code) {
+        return BaseResponse.onSuccess(SuccessStatus._OK, authService.kakaoLogin(code));
+    }
+
+    @Operation(summary = "카카오 로그아웃 API", description = "카카오 로그아웃 합니다._숙희")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
+            @ApiResponse(responseCode = "TOKEN400", description = "NOT_FOUND_TOKEN, 토큰을 찾을 수 없습니다."),
+    })
+    @DeleteMapping("/kakao/logout")
+    public BaseResponse<Long> kakaoLogout(@Parameter(name = "user", hidden = true) @AuthUser User user) {
+        authService.kakaoLogout(user.getId());
+        return BaseResponse.onSuccess(SuccessStatus._OK, user.getId());
+    }
+}

--- a/src/main/java/boosters/fundboost/user/auth/converter/AuthConverter.java
+++ b/src/main/java/boosters/fundboost/user/auth/converter/AuthConverter.java
@@ -1,0 +1,36 @@
+package boosters.fundboost.user.auth.converter;
+
+import boosters.fundboost.user.auth.dto.AuthResponse.TokenRefreshResponse;
+import boosters.fundboost.user.auth.dto.AuthResponse.OAuthResponse;
+import boosters.fundboost.user.auth.dto.KakaoProfile;
+import boosters.fundboost.user.domain.User;
+import boosters.fundboost.user.domain.enums.UserType;
+
+public class AuthConverter {
+    public static User toUser(KakaoProfile kakaoProfile) {
+        //TODO: 이름 닉네임, 이미지 디폴트 값 설정 필요
+        return User.builder()
+                .email(kakaoProfile.getKakao_account().getEmail())
+                .name("tmp")
+                .userType(UserType.USER)
+                .image("DEFAULT IMAGE")
+                .build();
+
+    }
+
+    public static OAuthResponse toOAuthResponse(String accessToken, String refreshToken, boolean isLogin, User user) {
+        return OAuthResponse.builder()
+                .userId(user.getId())
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .isLogin(isLogin)
+                .build();
+    }
+
+    public static TokenRefreshResponse toTokenRefreshResponse(String accessToken, String refreshToken) {
+        return TokenRefreshResponse.builder()
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .build();
+    }
+}

--- a/src/main/java/boosters/fundboost/user/auth/dto/AuthResponse.java
+++ b/src/main/java/boosters/fundboost/user/auth/dto/AuthResponse.java
@@ -1,0 +1,51 @@
+package boosters.fundboost.user.auth.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class AuthResponse {
+    @Getter
+    @Builder
+    @AllArgsConstructor(access = AccessLevel.PROTECTED)
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    public static class OAuthResponse {
+        Long userId;
+        String accessToken;
+        String refreshToken;
+        Boolean isLogin;
+    }
+
+    @Getter
+    @Builder
+    @AllArgsConstructor(access = AccessLevel.PROTECTED)
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    public static class KakaoOAuthToken {
+        @JsonProperty("access_token")
+        private String accessToken;
+        @JsonProperty("token_type")
+        private String tokenType;
+        @JsonProperty("refresh_token")
+        private String refreshToken;
+        @JsonProperty("id_token")
+        private String idToken;
+        @JsonProperty("expires_in")
+        private Integer expiresIn;
+        @JsonProperty("scope")
+        private String scope;
+        @JsonProperty("refresh_token_expires_in")
+        private Integer refreshTokenExpiresIn;
+    }
+
+    @Getter
+    @Builder
+    @AllArgsConstructor(access = AccessLevel.PROTECTED)
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    public static class TokenRefreshResponse {
+        String accessToken;
+        String refreshToken;
+    }
+}

--- a/src/main/java/boosters/fundboost/user/auth/dto/KakaoProfile.java
+++ b/src/main/java/boosters/fundboost/user/auth/dto/KakaoProfile.java
@@ -1,0 +1,17 @@
+package boosters.fundboost.user.auth.dto;
+
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.Getter;
+
+@Getter
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class KakaoProfile {
+    private KakaoAccount kakao_account;
+
+    @Getter
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public class KakaoAccount {
+        private String email;
+    }
+}

--- a/src/main/java/boosters/fundboost/user/auth/exception/AuthException.java
+++ b/src/main/java/boosters/fundboost/user/auth/exception/AuthException.java
@@ -1,0 +1,10 @@
+package boosters.fundboost.user.auth.exception;
+
+import boosters.fundboost.global.response.code.BaseErrorCode;
+import boosters.fundboost.global.response.exception.GeneralException;
+
+public class AuthException extends GeneralException {
+    public AuthException(BaseErrorCode code) {
+        super(code);
+    }
+}

--- a/src/main/java/boosters/fundboost/user/auth/service/AuthService.java
+++ b/src/main/java/boosters/fundboost/user/auth/service/AuthService.java
@@ -1,0 +1,13 @@
+package boosters.fundboost.user.auth.service;
+
+
+import boosters.fundboost.user.auth.dto.AuthResponse.TokenRefreshResponse;
+import boosters.fundboost.user.auth.dto.AuthResponse.OAuthResponse;
+
+public interface AuthService {
+    OAuthResponse kakaoLogin(String authorizationCode);
+
+    void kakaoLogout(Long userId);
+
+    TokenRefreshResponse refresh(String refreshToken);
+}

--- a/src/main/java/boosters/fundboost/user/auth/service/impl/AuthServiceImpl.java
+++ b/src/main/java/boosters/fundboost/user/auth/service/impl/AuthServiceImpl.java
@@ -1,0 +1,80 @@
+package boosters.fundboost.user.auth.service.impl;
+
+import boosters.fundboost.global.redis.exception.TokenException;
+import boosters.fundboost.global.redis.service.RefreshTokenService;
+import boosters.fundboost.global.response.code.status.ErrorStatus;
+import boosters.fundboost.global.security.jwt.JwtTokenProvider;
+import boosters.fundboost.global.security.provider.KakaoAuthProvider;
+import boosters.fundboost.user.auth.converter.AuthConverter;
+import boosters.fundboost.user.auth.dto.AuthResponse.KakaoOAuthToken;
+import boosters.fundboost.user.auth.dto.AuthResponse.OAuthResponse;
+import boosters.fundboost.user.auth.dto.AuthResponse.TokenRefreshResponse;
+import boosters.fundboost.user.auth.dto.KakaoProfile;
+import boosters.fundboost.user.auth.service.AuthService;
+import boosters.fundboost.user.domain.User;
+import boosters.fundboost.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+@Service
+@RequiredArgsConstructor
+public class AuthServiceImpl implements AuthService {
+    private final KakaoAuthProvider kakaoAuthProvider;
+    private final UserRepository userRepository;
+    private final JwtTokenProvider jwtTokenProvider;
+    private final RefreshTokenService refreshTokenService;
+
+    @Override
+    public OAuthResponse kakaoLogin(String code) {
+        KakaoOAuthToken kakaoToken = kakaoAuthProvider.getAccessToken(code);
+        KakaoProfile kakaoProfile = kakaoAuthProvider.getKakaoProfile(kakaoToken.getAccessToken());
+
+        Optional<User> user = userRepository.findByEmail(kakaoProfile.getKakao_account().getEmail());
+
+        AtomicBoolean isLogin = new AtomicBoolean(false);
+        User currentUser = user.orElseGet(() -> {
+            isLogin.set(true);
+            return userRepository.save(AuthConverter.toUser(kakaoProfile));
+        });
+
+        String accessToken = jwtTokenProvider.createToken(currentUser.getId().toString());
+        String refreshToken = saveRefreshToken(currentUser.getId());
+
+        return AuthConverter.toOAuthResponse(accessToken, refreshToken, isLogin.get(), currentUser);
+    }
+
+    @Override
+    public void kakaoLogout(Long userId) {
+        refreshTokenService.deleteToken(userId);
+    }
+
+    @Override
+    @Transactional
+    public TokenRefreshResponse refresh(String refreshToken) {
+        validateToken(refreshToken);
+        Long id = jwtTokenProvider.getId(refreshToken);
+
+        String newAccessToken = jwtTokenProvider.createToken(id.toString());
+        String newRefreshToken = saveRefreshToken(id);
+
+        return AuthConverter.toTokenRefreshResponse(newAccessToken, newRefreshToken);
+    }
+
+    private void validateToken(String refreshToken) {
+        jwtTokenProvider.validateToken(refreshToken);
+
+        if (!refreshTokenService.isEqualsToken(refreshToken))
+            throw new TokenException(ErrorStatus.NOT_EQUAL_TOKEN);
+    }
+
+    private String saveRefreshToken(Long userId) {
+        String refreshToken = jwtTokenProvider.createRefreshToken(userId.toString());
+        refreshTokenService.saveToken(refreshToken);
+
+        return refreshToken;
+    }
+}

--- a/src/main/java/boosters/fundboost/user/exception/UserException.java
+++ b/src/main/java/boosters/fundboost/user/exception/UserException.java
@@ -1,0 +1,10 @@
+package boosters.fundboost.user.exception;
+
+import boosters.fundboost.global.response.code.BaseErrorCode;
+import boosters.fundboost.global.response.exception.GeneralException;
+
+public class UserException extends GeneralException {
+    public UserException(BaseErrorCode code) {
+        super(code);
+    }
+}

--- a/src/main/java/boosters/fundboost/user/service/UserService.java
+++ b/src/main/java/boosters/fundboost/user/service/UserService.java
@@ -1,0 +1,8 @@
+package boosters.fundboost.user.service;
+
+
+import boosters.fundboost.user.domain.User;
+
+public interface UserService {
+    User getUser(Long userId);
+}

--- a/src/main/java/boosters/fundboost/user/service/UserServiceImpl.java
+++ b/src/main/java/boosters/fundboost/user/service/UserServiceImpl.java
@@ -1,0 +1,19 @@
+package boosters.fundboost.user.service;
+
+import boosters.fundboost.global.response.code.status.ErrorStatus;
+import boosters.fundboost.user.domain.User;
+import boosters.fundboost.user.exception.UserException;
+import boosters.fundboost.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UserServiceImpl implements UserService {
+    private final UserRepository userRepository;
+
+    @Override
+    public User getUser(Long userId) {
+        return userRepository.findById(userId).orElseThrow(() -> new UserException(ErrorStatus.USER_NOT_FOUND));
+    }
+}


### PR DESCRIPTION
### 📍 PR 타입
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [x] 기타 사소한 수정

### ❗️ 관련 이슈 링크
Close #10

### 🔁 변경 및 추가사항
- 유저와 토큰을 검증하는 리졸버 추가했습니다 5562f50caccdbc27304a0d4d69e3b04d30778496 
- API : 43a919bce737844d7c6ed80c5e97a70668acf21d 104d6820aaf6b589b4db1abee17e60f98a913d9c
- BaseResponse의 응답 매개변수 순서를 통일했습니다  e36f7dce27eb2848087550e8c27cb93d94be1cc8

### 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들

### ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] 불필요한 코드는 삭제했어요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Introduced authentication APIs for Kakao login, logout, and token refresh.
  - Added support for handling refresh tokens and user authentication with custom argument resolvers.
  - Implemented new annotations for marking authentication tokens and users.
  
- **Bug Fixes**
  - Enhanced error handling with new exception classes for user and authentication errors.
  
- **Documentation**
  - Improved API documentation with OpenAPI annotations for better usability.

- **Refactor**
  - Updated method signatures and response structures for clarity and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->