### PR TITLE
[FEAT] 제안서 작성 기능 구현 및 프로필 편집시 입력 받는 이미지 유효성 검증 추가

### DIFF
--- a/src/main/java/boosters/fundboost/company/domain/Company.java
+++ b/src/main/java/boosters/fundboost/company/domain/Company.java
@@ -2,6 +2,7 @@ package boosters.fundboost.company.domain;
 
 import boosters.fundboost.company.domain.enums.CompanyCategory;
 import boosters.fundboost.global.common.domain.BaseEntity;
+import boosters.fundboost.proposal.domain.Proposal;
 import boosters.fundboost.user.domain.User;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
@@ -13,12 +14,15 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToMany;
 import jakarta.persistence.OneToOne;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+
+import java.util.List;
 
 @Getter
 @Setter
@@ -34,6 +38,8 @@ public class Company extends BaseEntity {
     @OneToOne(cascade = CascadeType.REMOVE, orphanRemoval = true, fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
     private User user;
+    @OneToMany(mappedBy = "company", cascade = CascadeType.REMOVE, orphanRemoval = true)
+    private List<Proposal> proposals;
     @Enumerated(EnumType.STRING)
     private CompanyCategory category;
 

--- a/src/main/java/boosters/fundboost/company/exception/CompanyException.java
+++ b/src/main/java/boosters/fundboost/company/exception/CompanyException.java
@@ -1,0 +1,10 @@
+package boosters.fundboost.company.exception;
+
+import boosters.fundboost.global.response.code.BaseErrorCode;
+import boosters.fundboost.global.response.exception.GeneralException;
+
+public class CompanyException extends GeneralException {
+    public CompanyException(BaseErrorCode code) {
+        super(code);
+    }
+}

--- a/src/main/java/boosters/fundboost/company/service/CompanyService.java
+++ b/src/main/java/boosters/fundboost/company/service/CompanyService.java
@@ -7,8 +7,10 @@ import boosters.fundboost.company.dto.request.CompanyLoginRequest;
 import boosters.fundboost.company.dto.request.CompanyRankingRequest;
 import boosters.fundboost.company.dto.request.CompanyRegisterRequest;
 import boosters.fundboost.company.dto.response.CompanyRankingResponse;
+import boosters.fundboost.company.exception.CompanyException;
 import boosters.fundboost.company.repository.CompanyRepository;
 import boosters.fundboost.company.auth.email.service.EmailService;
+import boosters.fundboost.global.response.code.status.ErrorStatus;
 import boosters.fundboost.global.security.jwt.JwtTokenProvider;
 import boosters.fundboost.user.domain.User;
 import boosters.fundboost.user.domain.enums.Tag;
@@ -121,5 +123,10 @@ public class CompanyService {
         return companies.entrySet().stream()
                 .map(entry -> CompanyRankingConverter.toCompanyRankingResponse(entry.getKey(), entry.getValue()))
                 .collect(Collectors.toList());
+    }
+
+    public Company findById(Long companyId) {
+        return companyRepository.findById(companyId)
+                .orElseThrow(() -> new CompanyException(ErrorStatus.COMPANY_NOT_FOUND));
     }
 }

--- a/src/main/java/boosters/fundboost/global/common/domain/enums/UploadType.java
+++ b/src/main/java/boosters/fundboost/global/common/domain/enums/UploadType.java
@@ -1,0 +1,17 @@
+package boosters.fundboost.global.common.domain.enums;
+
+public enum UploadType {
+    IMAGE("project-images"),
+    FILE("proposal-files"),
+    ;
+
+    private final String directory;
+
+    UploadType(String directory) {
+        this.directory = directory;
+    }
+
+    public String getDirectory() {
+        return directory;
+    }
+}

--- a/src/main/java/boosters/fundboost/global/exception/S3Exception.java
+++ b/src/main/java/boosters/fundboost/global/exception/S3Exception.java
@@ -1,0 +1,10 @@
+package boosters.fundboost.global.exception;
+
+import boosters.fundboost.global.response.code.BaseErrorCode;
+import boosters.fundboost.global.response.exception.GeneralException;
+
+public class S3Exception extends GeneralException {
+    public S3Exception(BaseErrorCode code) {
+        super(code);
+    }
+}

--- a/src/main/java/boosters/fundboost/global/response/code/status/ErrorStatus.java
+++ b/src/main/java/boosters/fundboost/global/response/code/status/ErrorStatus.java
@@ -37,6 +37,8 @@ public enum ErrorStatus implements BaseErrorCode {
     REVIEW_USER_NOT_FOUND(HttpStatus.NOT_FOUND, "REVIEW401", "유효하지 않은 사용자입니다."),
     REVIEW_BOOST_NOT_FOUND(HttpStatus.NOT_FOUND, "REVIEW402", "해당 프로젝트에 대한 사용자의 후원 기록이 없습니다."),
     REVIEW_UNAUTHORIZED_ACCESS(HttpStatus.FORBIDDEN, "REVIEW403", "마감후기는 프로젝트 등록자만 작성할 수 있습니다."),
+    // S3
+    INVALID_EXTENSION(HttpStatus.BAD_REQUEST, "S3400", "지원하지 않는 확장자입니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/boosters/fundboost/global/response/code/status/ErrorStatus.java
+++ b/src/main/java/boosters/fundboost/global/response/code/status/ErrorStatus.java
@@ -39,6 +39,8 @@ public enum ErrorStatus implements BaseErrorCode {
     REVIEW_UNAUTHORIZED_ACCESS(HttpStatus.FORBIDDEN, "REVIEW403", "마감후기는 프로젝트 등록자만 작성할 수 있습니다."),
     // S3
     INVALID_EXTENSION(HttpStatus.BAD_REQUEST, "S3400", "지원하지 않는 확장자입니다."),
+    // COMPANY
+    COMPANY_NOT_FOUND(HttpStatus.NOT_FOUND, "COMPANY400", "기업을 찾을 수 없습니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/boosters/fundboost/global/uploader/S3UploaderService.java
+++ b/src/main/java/boosters/fundboost/global/uploader/S3UploaderService.java
@@ -1,20 +1,28 @@
 package boosters.fundboost.global.uploader;
 
+import boosters.fundboost.global.utils.FileValidator;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
+
+import java.util.Arrays;
 
 @Service
 @RequiredArgsConstructor
 public class S3UploaderService {
     private final S3Uploader s3Uploader;
 
-    @Transactional
-    public String upload(MultipartFile image) {
-        if (image != null) {
-            return s3Uploader.upload(image, "project-images");
-        }
-        return null;
+    public String uploadImage(MultipartFile image, String directory) {
+        FileValidator.validateFileExtension(image, Arrays.asList("jpg", "jpeg", "png"));
+        return upload(image, directory);
+    }
+
+    public String uploadFile(MultipartFile file, String directory) {
+        FileValidator.validateFileExtension(file, Arrays.asList("pdf", "doc", "docx", "ppt", "pptx", "xls", "xlsx", "hwp", "zip"));
+        return upload(file, directory);
+    }
+
+    private String upload(MultipartFile file, String directory) {
+        return s3Uploader.upload(file, directory);
     }
 }

--- a/src/main/java/boosters/fundboost/global/utils/FileValidator.java
+++ b/src/main/java/boosters/fundboost/global/utils/FileValidator.java
@@ -1,0 +1,25 @@
+package boosters.fundboost.global.utils;
+
+import boosters.fundboost.global.exception.S3Exception;
+import boosters.fundboost.global.response.code.status.ErrorStatus;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+public class FileValidator {
+    public static void validateFileExtension(MultipartFile file, List<String> allowedExtensions) {
+        String fileName = file.getOriginalFilename();
+        String fileExtension = getFileExtension(fileName);
+
+        if (!allowedExtensions.contains(fileExtension.toLowerCase())) {
+            throw new S3Exception(ErrorStatus.INVALID_EXTENSION);
+        }
+    }
+
+    private static String getFileExtension(String fileName) {
+        if (fileName != null && fileName.contains(".")) {
+            return fileName.substring(fileName.lastIndexOf(".") + 1);
+        }
+        return "";
+    }
+}

--- a/src/main/java/boosters/fundboost/proposal/controller/ProposalController.java
+++ b/src/main/java/boosters/fundboost/proposal/controller/ProposalController.java
@@ -27,6 +27,9 @@ public class ProposalController {
     @Operation(summary = "제안서 작성 API", description = "제안서를 작성합니다._숙희")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
+            @ApiResponse(responseCode = "PROJECT400", description = "PROJECT_NOT_FOUND, 프로젝트를 찾을 수 없습니다."),
+            @ApiResponse(responseCode = "COMPANY400", description = "COMPANY_NOT_FOUND, 기업을 찾을 수 없습니다."),
+            @ApiResponse(responseCode = "S3400", description = "INVALID_EXTENSION, 지원하지 않는 확장자입니다.")
     })
     @PostMapping(name = "/write", consumes = {"multipart/form-data"})
     public BaseResponse<?> createProposal(@Parameter(name = "user", hidden = true) @AuthUser User user,

--- a/src/main/java/boosters/fundboost/proposal/controller/ProposalController.java
+++ b/src/main/java/boosters/fundboost/proposal/controller/ProposalController.java
@@ -28,7 +28,7 @@ public class ProposalController {
     @ApiResponses(value = {
             @ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
     })
-    @PostMapping(name = "/proposal", consumes = {"multipart/form-data"})
+    @PostMapping(name = "/write", consumes = {"multipart/form-data"})
     public BaseResponse<?> createProposal(@Parameter(name = "user", hidden = true) @AuthUser User user,
                                           @ModelAttribute ProposalRequest request) {
         proposalService.writeProposal(user, request);

--- a/src/main/java/boosters/fundboost/proposal/controller/ProposalController.java
+++ b/src/main/java/boosters/fundboost/proposal/controller/ProposalController.java
@@ -1,0 +1,37 @@
+package boosters.fundboost.proposal.controller;
+
+import boosters.fundboost.global.response.BaseResponse;
+import boosters.fundboost.global.response.code.status.SuccessStatus;
+import boosters.fundboost.global.security.handler.annotation.AuthUser;
+import boosters.fundboost.proposal.service.ProposalService;
+import boosters.fundboost.user.domain.User;
+import boosters.fundboost.user.dto.request.ProposalRequest;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/proposal")
+@Tag(name = "Proposal 🔥", description = "제안서 관련 API")
+public class ProposalController {
+    private final ProposalService proposalService;
+
+    @Operation(summary = "제안서 작성 API", description = "제안서를 작성합니다._숙희")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
+    })
+    @PostMapping(name = "/proposal", consumes = {"multipart/form-data"})
+    public BaseResponse<?> createProposal(@Parameter(name = "user", hidden = true) @AuthUser User user,
+                                          @ModelAttribute ProposalRequest request) {
+        proposalService.writeProposal(user, request);
+        return BaseResponse.onSuccess(SuccessStatus._NO_CONTENT, null);
+    }
+}

--- a/src/main/java/boosters/fundboost/proposal/domain/Proposal.java
+++ b/src/main/java/boosters/fundboost/proposal/domain/Proposal.java
@@ -11,6 +11,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -31,4 +32,13 @@ public class Proposal extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "project_id", nullable = false)
     private Project project;
+
+    @Builder
+    public Proposal(String title, String file, String content, Project project) {
+        this.title = title;
+        this.content = content;
+        this.viewedAt = LocalDate.now();
+        this.file = file;
+        this.project = project;
+    }
 }

--- a/src/main/java/boosters/fundboost/proposal/domain/Proposal.java
+++ b/src/main/java/boosters/fundboost/proposal/domain/Proposal.java
@@ -1,5 +1,6 @@
 package boosters.fundboost.proposal.domain;
 
+import boosters.fundboost.company.domain.Company;
 import boosters.fundboost.global.common.domain.BaseEntity;
 import boosters.fundboost.project.domain.Project;
 import jakarta.persistence.Column;
@@ -32,13 +33,17 @@ public class Proposal extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "project_id", nullable = false)
     private Project project;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "company_id", nullable = false)
+    private Company company;
 
     @Builder
-    public Proposal(String title, String file, String content, Project project) {
+    public Proposal(String title, String file, String content, Project project, Company company) {
         this.title = title;
         this.content = content;
         this.viewedAt = LocalDate.now();
         this.file = file;
         this.project = project;
+        this.company = company;
     }
 }

--- a/src/main/java/boosters/fundboost/proposal/repository/ProposalRepository.java
+++ b/src/main/java/boosters/fundboost/proposal/repository/ProposalRepository.java
@@ -1,0 +1,7 @@
+package boosters.fundboost.proposal.repository;
+
+import boosters.fundboost.proposal.domain.Proposal;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ProposalRepository extends JpaRepository<Proposal, Long> {
+}

--- a/src/main/java/boosters/fundboost/proposal/service/ProposalService.java
+++ b/src/main/java/boosters/fundboost/proposal/service/ProposalService.java
@@ -1,0 +1,8 @@
+package boosters.fundboost.proposal.service;
+
+import boosters.fundboost.user.domain.User;
+import boosters.fundboost.user.dto.request.ProposalRequest;
+
+public interface ProposalService {
+    void writeProposal(User user, ProposalRequest request);
+}

--- a/src/main/java/boosters/fundboost/proposal/service/ProposalServiceImpl.java
+++ b/src/main/java/boosters/fundboost/proposal/service/ProposalServiceImpl.java
@@ -1,5 +1,7 @@
 package boosters.fundboost.proposal.service;
 
+import boosters.fundboost.company.domain.Company;
+import boosters.fundboost.company.service.CompanyService;
 import boosters.fundboost.global.common.domain.enums.UploadType;
 import boosters.fundboost.global.uploader.S3UploaderService;
 import boosters.fundboost.project.domain.Project;
@@ -19,27 +21,30 @@ import java.util.Optional;
 public class ProposalServiceImpl implements ProposalService {
     private final ProposalRepository proposalRepository;
     private final ProjectService projectService;
+    private final CompanyService companyService;
     private final S3UploaderService s3UploaderService;
 
     @Override
     @Transactional
     public void writeProposal(User user, ProposalRequest request) {
         Project project = projectService.findById(request.getProjectId());
+        Company company = companyService.findById(request.getCompanyId());
         String fileUrl = Optional.ofNullable(request.getFile())
                 .filter(image -> !image.isEmpty())
                 .map(image -> s3UploaderService.uploadFile(image, UploadType.FILE.getDirectory()))
                 .orElse(null);
 
-        Proposal proposal = createProposal(project, request, fileUrl);
+        Proposal proposal = createProposal(project, request, fileUrl, company);
 
         proposalRepository.save(proposal);
     }
 
-    private Proposal createProposal(Project project, ProposalRequest request, String file) {
+    private Proposal createProposal(Project project, ProposalRequest request, String file, Company company) {
         return Proposal.builder()
                 .project(project)
                 .title(request.getTitle())
                 .content(request.getContent())
+                .company(company)
                 .file(file).build();
     }
 }

--- a/src/main/java/boosters/fundboost/proposal/service/ProposalServiceImpl.java
+++ b/src/main/java/boosters/fundboost/proposal/service/ProposalServiceImpl.java
@@ -1,0 +1,45 @@
+package boosters.fundboost.proposal.service;
+
+import boosters.fundboost.global.common.domain.enums.UploadType;
+import boosters.fundboost.global.uploader.S3UploaderService;
+import boosters.fundboost.project.domain.Project;
+import boosters.fundboost.project.service.ProjectService;
+import boosters.fundboost.proposal.domain.Proposal;
+import boosters.fundboost.proposal.repository.ProposalRepository;
+import boosters.fundboost.user.domain.User;
+import boosters.fundboost.user.dto.request.ProposalRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class ProposalServiceImpl implements ProposalService {
+    private final ProposalRepository proposalRepository;
+    private final ProjectService projectService;
+    private final S3UploaderService s3UploaderService;
+
+    @Override
+    @Transactional
+    public void writeProposal(User user, ProposalRequest request) {
+        Project project = projectService.findById(request.getProjectId());
+        String fileUrl = Optional.ofNullable(request.getFile())
+                .filter(image -> !image.isEmpty())
+                .map(image -> s3UploaderService.uploadFile(image, UploadType.FILE.getDirectory()))
+                .orElse(null);
+
+        Proposal proposal = createProposal(project, request, fileUrl);
+
+        proposalRepository.save(proposal);
+    }
+
+    private Proposal createProposal(Project project, ProposalRequest request, String file) {
+        return Proposal.builder()
+                .project(project)
+                .title(request.getTitle())
+                .content(request.getContent())
+                .file(file).build();
+    }
+}

--- a/src/main/java/boosters/fundboost/user/dto/request/ProfileEditRequest.java
+++ b/src/main/java/boosters/fundboost/user/dto/request/ProfileEditRequest.java
@@ -7,9 +7,9 @@ import org.springframework.web.multipart.MultipartFile;
 @Getter
 @Setter
 public class ProfileEditRequest {
-    String link;
-    String introduceTitle;
-    String introduceContent;
-    MultipartFile image;
+    private String link;
+    private String introduceTitle;
+    private String introduceContent;
+    private MultipartFile image;
 
 }

--- a/src/main/java/boosters/fundboost/user/dto/request/ProposalRequest.java
+++ b/src/main/java/boosters/fundboost/user/dto/request/ProposalRequest.java
@@ -8,8 +8,9 @@ import org.springframework.web.multipart.MultipartFile;
 @Getter
 @Setter
 public class ProposalRequest {
-    @NotNull(message = "프로젝트 아이디는 필수입니다.")
     private long projectId;
+    @NotNull(message = "기업아이디는 필수입니다.")
+    private long companyId;
     @NotNull(message = "제목은 필수입니다.")
     private String title;
     @NotNull(message = "내용은 필수입니다.")

--- a/src/main/java/boosters/fundboost/user/dto/request/ProposalRequest.java
+++ b/src/main/java/boosters/fundboost/user/dto/request/ProposalRequest.java
@@ -1,0 +1,18 @@
+package boosters.fundboost.user.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.web.multipart.MultipartFile;
+
+@Getter
+@Setter
+public class ProposalRequest {
+    @NotNull(message = "프로젝트 아이디는 필수입니다.")
+    private long projectId;
+    @NotNull(message = "제목은 필수입니다.")
+    private String title;
+    @NotNull(message = "내용은 필수입니다.")
+    private String content;
+    private MultipartFile file;
+}

--- a/src/main/java/boosters/fundboost/user/service/UserServiceImpl.java
+++ b/src/main/java/boosters/fundboost/user/service/UserServiceImpl.java
@@ -2,6 +2,7 @@ package boosters.fundboost.user.service;
 
 import boosters.fundboost.boost.service.BoostService;
 import boosters.fundboost.follow.service.FollowService;
+import boosters.fundboost.global.common.domain.enums.UploadType;
 import boosters.fundboost.global.response.code.status.ErrorStatus;
 import boosters.fundboost.global.uploader.S3UploaderService;
 import boosters.fundboost.like.service.LikeService;
@@ -20,6 +21,8 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -62,7 +65,11 @@ public class UserServiceImpl implements UserService {
     @Override
     @Transactional
     public void editProfile(User user, ProfileEditRequest request) {
-        String imageUrl = s3UploaderService.upload(request.getImage());
+        String imageUrl = Optional.ofNullable(request.getImage())
+                .filter(image -> !image.isEmpty())
+                .map(image -> s3UploaderService.uploadImage(image, UploadType.IMAGE.getDirectory()))
+                .orElse(null);
+
         user.updateUser(request, imageUrl);
     }
 }


### PR DESCRIPTION
### 📍 PR 타입
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [x] 기타 사소한 수정

### ❗️ 관련 이슈 링크
Close #60

### 🔁 변경 및 추가사항
- S3Uploader에 여러 기능을 구현해두셨는데 제가 S3UploaderService를 만들어서 사용했습니다 ㅜㅜ
이번기능 구현하면서 깨달아서 일단은 기존에 작성해둔 S3UploaderService 클래스에 기능을 추가해서 구현했습니다
-> 이거 api다 짜고 나서 리팩토링하겠습니다!!
- S3UploaderService  내부에서는 파일 유효성 검사를 진행합니다  6bcdc5de52b8ea1ca7a445f8b32a2c79ec2bb88a
- 이미지, 파일 업로드 경로가 달라 enum값으로 경로를 불러와 사용했습니다 00c06964d5371065cb07de7242b228fba780d1ea


- 기존 제안서에는 프로젝트 정보가 들어있었는데 GUI를 확인해보니 프로젝트를 제안하는 것이 아닌 기업에 자유형식의 제안서를 낼 수 있는 것으로 확인했습니다
![image](https://github.com/user-attachments/assets/86d48748-685c-451c-8856-31d9761960be)
지금 확인한바로는 제안서에서 프로젝트는 제거되어도 될 것 같은데 혹시 몰라서 그냥 두었습니다!
=> 이거 바로 다음 PR에서 Project제거하고 User와 연결되도록 수정했습니다😂

### 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들

### ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] 불필요한 코드는 삭제했어요.
