### PR TITLE
[FEAT] 상대의 마이페이지 조회 기능 구현 

### DIFF
--- a/src/main/java/boosters/fundboost/global/config/WebConfig.java
+++ b/src/main/java/boosters/fundboost/global/config/WebConfig.java
@@ -1,5 +1,6 @@
 package boosters.fundboost.global.config;
 
+import boosters.fundboost.global.security.handler.resolver.AuthInfoArgumentResolver;
 import boosters.fundboost.global.security.handler.resolver.AuthUserArgumentResolver;
 import boosters.fundboost.global.security.handler.resolver.TokenArgumentResolver;
 import lombok.RequiredArgsConstructor;
@@ -15,6 +16,7 @@ import java.util.List;
 public class WebConfig implements WebMvcConfigurer {
     private final AuthUserArgumentResolver authUserArgumentResolver;
     private final TokenArgumentResolver tokenArgumentResolver;
+    private final AuthInfoArgumentResolver authInfoArgumentResolver;
 
     @Override
     public void addCorsMappings(CorsRegistry registry) {
@@ -30,5 +32,6 @@ public class WebConfig implements WebMvcConfigurer {
     public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
         resolvers.add(authUserArgumentResolver);
         resolvers.add(tokenArgumentResolver);
+        resolvers.add(authInfoArgumentResolver);
     }
 }

--- a/src/main/java/boosters/fundboost/global/controller/UserCompanyController.java
+++ b/src/main/java/boosters/fundboost/global/controller/UserCompanyController.java
@@ -5,6 +5,7 @@ import boosters.fundboost.global.response.code.status.SuccessStatus;
 import boosters.fundboost.global.security.handler.annotation.AuthUser;
 import boosters.fundboost.user.domain.User;
 import boosters.fundboost.user.dto.request.ProfileEditRequest;
+import boosters.fundboost.user.dto.response.PeerMyPageResponse;
 import boosters.fundboost.user.service.UserService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -12,8 +13,11 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -35,5 +39,17 @@ public class UserCompanyController {
             @ModelAttribute ProfileEditRequest request) {
         userService.editProfile(user, request);
         return BaseResponse.onSuccess(SuccessStatus._NO_CONTENT, null);
+    }
+
+    @Operation(summary = "상대의 마이페이지 조회 API", description = "다른 사람의 마이페이지를 조회합니다._숙희")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
+            @ApiResponse(responseCode = "USER400",description = "USER_NOT_FOUND, 유저를 찾을 수 없습니다."),
+            @ApiResponse(responseCode = "USER402",description = "SELF_PROFILE_ACCESS_NOT_ALLOWED. 해당 API로 본인의 마이페이지는 조회할 수 없습니다."),
+    })
+    @GetMapping(value = "/{peerId}")
+    public BaseResponse<PeerMyPageResponse> getPeerProfile(@PathVariable Long peerId,
+                                                           @RequestBody Long userId) {
+        return BaseResponse.onSuccess(SuccessStatus._OK, userService.getPeerProfile(peerId,userId));
     }
 }

--- a/src/main/java/boosters/fundboost/global/controller/UserCompanyController.java
+++ b/src/main/java/boosters/fundboost/global/controller/UserCompanyController.java
@@ -2,6 +2,7 @@ package boosters.fundboost.global.controller;
 
 import boosters.fundboost.global.response.BaseResponse;
 import boosters.fundboost.global.response.code.status.SuccessStatus;
+import boosters.fundboost.global.security.handler.annotation.AuthInfo;
 import boosters.fundboost.global.security.handler.annotation.AuthUser;
 import boosters.fundboost.user.domain.User;
 import boosters.fundboost.user.dto.request.ProfileEditRequest;
@@ -17,7 +18,6 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -44,12 +44,12 @@ public class UserCompanyController {
     @Operation(summary = "상대의 마이페이지 조회 API", description = "다른 사람의 마이페이지를 조회합니다._숙희")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
-            @ApiResponse(responseCode = "USER400",description = "USER_NOT_FOUND, 유저를 찾을 수 없습니다."),
-            @ApiResponse(responseCode = "USER402",description = "SELF_PROFILE_ACCESS_NOT_ALLOWED. 해당 API로 본인의 마이페이지는 조회할 수 없습니다."),
+            @ApiResponse(responseCode = "USER400", description = "USER_NOT_FOUND, 유저를 찾을 수 없습니다."),
+            @ApiResponse(responseCode = "USER402", description = "SELF_PROFILE_ACCESS_NOT_ALLOWED. 해당 API로 본인의 마이페이지는 조회할 수 없습니다."),
     })
-    @GetMapping(value = "/{peerId}")
+    @GetMapping(value = "/{peerId}/profile")
     public BaseResponse<PeerMyPageResponse> getPeerProfile(@PathVariable Long peerId,
-                                                           @RequestBody Long userId) {
-        return BaseResponse.onSuccess(SuccessStatus._OK, userService.getPeerProfile(peerId,userId));
+                                                           @Parameter(name = "user", hidden = true) @AuthInfo Long userId) {
+        return BaseResponse.onSuccess(SuccessStatus._OK, userService.getPeerProfile(peerId, userId));
     }
 }

--- a/src/main/java/boosters/fundboost/global/response/code/status/ErrorStatus.java
+++ b/src/main/java/boosters/fundboost/global/response/code/status/ErrorStatus.java
@@ -24,6 +24,7 @@ public enum ErrorStatus implements BaseErrorCode {
     //USER
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "USER400", "유저를 찾을 수 없습니다."),
     UNAUTHORIZED_USER(HttpStatus.UNAUTHORIZED, "USER401", "인증되지 않은 유저입니다."),
+    SELF_PROFILE_ACCESS_NOT_ALLOWED(HttpStatus.FORBIDDEN, "USER402", "해당 API로 본인의 마이페이지는 조회할 수 없습니다."),
     // PROJECT
     PROJECT_NOT_FOUND(HttpStatus.NOT_FOUND, "PROJECT400", "프로젝트를 찾을 수 없습니다."),
     PROJECT_ALREADY_EXISTS(HttpStatus.CONFLICT, "PROJECT401", "이미 존재하는 프로젝트입니다."),

--- a/src/main/java/boosters/fundboost/global/security/handler/annotation/AuthInfo.java
+++ b/src/main/java/boosters/fundboost/global/security/handler/annotation/AuthInfo.java
@@ -1,0 +1,10 @@
+package boosters.fundboost.global.security.handler.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.PARAMETER)
+public @interface AuthInfo {}

--- a/src/main/java/boosters/fundboost/global/security/handler/resolver/AuthInfoArgumentResolver.java
+++ b/src/main/java/boosters/fundboost/global/security/handler/resolver/AuthInfoArgumentResolver.java
@@ -1,0 +1,44 @@
+package boosters.fundboost.global.security.handler.resolver;
+
+import boosters.fundboost.global.security.handler.annotation.AuthInfo;
+import boosters.fundboost.global.security.util.SecurityUtils;
+import boosters.fundboost.user.auth.exception.AuthException;
+import boosters.fundboost.user.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.MethodParameter;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+@Component
+@RequiredArgsConstructor
+public class AuthInfoArgumentResolver implements HandlerMethodArgumentResolver {
+    private final UserService userService;
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.getParameterType().equals(Long.class)
+                && parameter.hasParameterAnnotation(AuthInfo.class);
+    }
+
+    @Override
+    public Object resolveArgument(
+            MethodParameter parameter,
+            ModelAndViewContainer mavContainer,
+            NativeWebRequest webRequest,
+            WebDataBinderFactory binderFactory) throws AuthException {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+        if ((authentication == null) || authentication.getName().equals("anonymousUser")) {
+            return null;
+        }
+
+        String userEmail = SecurityUtils.getAuthUserEmail(authentication);
+        return userService.getUser(userEmail).getId();
+    }
+
+}

--- a/src/main/java/boosters/fundboost/global/security/handler/resolver/AuthUserArgumentResolver.java
+++ b/src/main/java/boosters/fundboost/global/security/handler/resolver/AuthUserArgumentResolver.java
@@ -2,13 +2,12 @@ package boosters.fundboost.global.security.handler.resolver;
 
 import boosters.fundboost.global.response.code.status.ErrorStatus;
 import boosters.fundboost.global.security.handler.annotation.AuthUser;
+import boosters.fundboost.global.security.util.SecurityUtils;
 import boosters.fundboost.user.auth.exception.AuthException;
 import boosters.fundboost.user.domain.User;
-import boosters.fundboost.user.exception.UserException;
 import boosters.fundboost.user.service.UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.core.MethodParameter;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
@@ -35,22 +34,13 @@ public class AuthUserArgumentResolver implements HandlerMethodArgumentResolver {
             NativeWebRequest webRequest,
             WebDataBinderFactory binderFactory) throws AuthException {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        Object principal = null;
-
         if (authentication != null) {
             if (authentication.getName().equals("anonymousUser")) {
                 throw new AuthException(ErrorStatus.UNAUTHORIZED_USER);
             }
-            principal = authentication.getPrincipal();
         }
-        if (principal == null || principal.getClass() == String.class) {
-            throw new UserException(ErrorStatus.USER_NOT_FOUND);
-        }
-        UsernamePasswordAuthenticationToken authenticationToken =
-                (UsernamePasswordAuthenticationToken) authentication;
 
-        String userEmail = authenticationToken.getName();
-
+        String userEmail = SecurityUtils.getAuthUserEmail(authentication);
         return userService.getUser(userEmail);
     }
 }

--- a/src/main/java/boosters/fundboost/global/security/util/SecurityUtils.java
+++ b/src/main/java/boosters/fundboost/global/security/util/SecurityUtils.java
@@ -1,6 +1,9 @@
 package boosters.fundboost.global.security.util;
 
+import boosters.fundboost.global.response.code.status.ErrorStatus;
 import boosters.fundboost.global.security.userdetails.CustomUserDetails;
+import boosters.fundboost.user.exception.UserException;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 
@@ -12,5 +15,16 @@ public class SecurityUtils {
         }
         CustomUserDetails userDetails = (CustomUserDetails) authentication.getPrincipal();
         return userDetails.getUserId(); // User ID 반환
+    }
+
+    public static String getAuthUserEmail(Authentication authentication) {
+        Object principal = authentication.getPrincipal();
+        if (principal == null || principal.getClass() == String.class) {
+            throw new UserException(ErrorStatus.USER_NOT_FOUND);
+        }
+        UsernamePasswordAuthenticationToken authenticationToken =
+                (UsernamePasswordAuthenticationToken) authentication;
+
+        return authenticationToken.getName();
     }
 }

--- a/src/main/java/boosters/fundboost/global/utils/MyPageValidator.java
+++ b/src/main/java/boosters/fundboost/global/utils/MyPageValidator.java
@@ -1,0 +1,13 @@
+package boosters.fundboost.global.utils;
+
+import boosters.fundboost.global.response.code.status.ErrorStatus;
+import boosters.fundboost.user.exception.UserException;
+
+public class MyPageValidator {
+    public static void validatePeerId(Long peerId, Long userId) {
+        if (peerId.equals(userId)) {
+            throw new UserException(ErrorStatus.SELF_PROFILE_ACCESS_NOT_ALLOWED);
+        }
+    }
+}
+

--- a/src/main/java/boosters/fundboost/user/converter/MyPageConverter.java
+++ b/src/main/java/boosters/fundboost/user/converter/MyPageConverter.java
@@ -1,6 +1,7 @@
 package boosters.fundboost.user.converter;
 
 import boosters.fundboost.user.domain.User;
+import boosters.fundboost.user.domain.enums.UserType;
 import boosters.fundboost.user.dto.response.PeerMyPageResponse;
 import boosters.fundboost.user.dto.response.UserMyPageResponse;
 
@@ -21,6 +22,7 @@ public class MyPageConverter {
                 .userInfo(toUserMyPageResponse(user, followingCount, followerCount))
                 .title(user.getTitle())
                 .content(user.getContent())
+                .isCompany(user.getUserType().equals(UserType.COMPANY))
                 .build();
     }
 }

--- a/src/main/java/boosters/fundboost/user/converter/MyPageConverter.java
+++ b/src/main/java/boosters/fundboost/user/converter/MyPageConverter.java
@@ -1,6 +1,7 @@
 package boosters.fundboost.user.converter;
 
 import boosters.fundboost.user.domain.User;
+import boosters.fundboost.user.dto.response.PeerMyPageResponse;
 import boosters.fundboost.user.dto.response.UserMyPageResponse;
 
 public class MyPageConverter {
@@ -12,6 +13,14 @@ public class MyPageConverter {
                 .tag(user.getTag().getValue())
                 .followingCount(followingCount)
                 .followerCount(followerCount)
+                .build();
+    }
+
+    public static PeerMyPageResponse toPeerMyPageResponse(User user, long followingCount, long followerCount) {
+        return PeerMyPageResponse.builder()
+                .userInfo(toUserMyPageResponse(user, followingCount, followerCount))
+                .title(user.getTitle())
+                .content(user.getContent())
                 .build();
     }
 }

--- a/src/main/java/boosters/fundboost/user/converter/MyPageConverter.java
+++ b/src/main/java/boosters/fundboost/user/converter/MyPageConverter.java
@@ -3,7 +3,7 @@ package boosters.fundboost.user.converter;
 import boosters.fundboost.user.domain.User;
 import boosters.fundboost.user.dto.response.UserMyPageResponse;
 
-public class UserMyPageConverter {
+public class MyPageConverter {
     public static UserMyPageResponse toUserMyPageResponse(User user, long followingCount, long followerCount) {
         return UserMyPageResponse.builder()
                 .name(user.getName())

--- a/src/main/java/boosters/fundboost/user/converter/UserMyPageConverter.java
+++ b/src/main/java/boosters/fundboost/user/converter/UserMyPageConverter.java
@@ -6,6 +6,7 @@ import boosters.fundboost.user.dto.response.UserMyPageResponse;
 public class UserMyPageConverter {
     public static UserMyPageResponse toUserMyPageResponse(User user, long followingCount, long followerCount) {
         return UserMyPageResponse.builder()
+                .name(user.getName())
                 .image(user.getImage())
                 .link(user.getLink())
                 .tag(user.getTag().getValue())

--- a/src/main/java/boosters/fundboost/user/dto/response/PeerMyPageResponse.java
+++ b/src/main/java/boosters/fundboost/user/dto/response/PeerMyPageResponse.java
@@ -1,0 +1,17 @@
+package boosters.fundboost.user.dto.response;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PeerMyPageResponse {
+    private UserMyPageResponse userInfo;
+    private String title;
+    private String content;
+}

--- a/src/main/java/boosters/fundboost/user/dto/response/PeerMyPageResponse.java
+++ b/src/main/java/boosters/fundboost/user/dto/response/PeerMyPageResponse.java
@@ -14,4 +14,5 @@ public class PeerMyPageResponse {
     private UserMyPageResponse userInfo;
     private String title;
     private String content;
+    private boolean isCompany;
 }

--- a/src/main/java/boosters/fundboost/user/dto/response/UserMyPageResponse.java
+++ b/src/main/java/boosters/fundboost/user/dto/response/UserMyPageResponse.java
@@ -11,6 +11,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class UserMyPageResponse {
+    private String name;
     private String image;
     private String link;
     private String tag;

--- a/src/main/java/boosters/fundboost/user/service/UserService.java
+++ b/src/main/java/boosters/fundboost/user/service/UserService.java
@@ -3,6 +3,7 @@ package boosters.fundboost.user.service;
 import boosters.fundboost.project.dto.response.ProjectPreviewResponse;
 import boosters.fundboost.user.domain.User;
 import boosters.fundboost.user.dto.request.ProfileEditRequest;
+import boosters.fundboost.user.dto.response.PeerMyPageResponse;
 import boosters.fundboost.user.dto.response.UserMyPageResponse;
 import org.springframework.data.domain.Page;
 
@@ -16,4 +17,6 @@ public interface UserService {
     Page<ProjectPreviewResponse> getBoostedProjects(Long userId, int page);
 
     void editProfile(User user, ProfileEditRequest request);
+
+    PeerMyPageResponse getPeerProfile(Long peerId, Long userId);
 }

--- a/src/main/java/boosters/fundboost/user/service/UserServiceImpl.java
+++ b/src/main/java/boosters/fundboost/user/service/UserServiceImpl.java
@@ -5,13 +5,15 @@ import boosters.fundboost.follow.service.FollowService;
 import boosters.fundboost.global.common.domain.enums.UploadType;
 import boosters.fundboost.global.response.code.status.ErrorStatus;
 import boosters.fundboost.global.uploader.S3UploaderService;
+import boosters.fundboost.global.utils.MyPageValidator;
 import boosters.fundboost.like.service.LikeService;
 import boosters.fundboost.project.converter.ProjectConverter;
 import boosters.fundboost.project.domain.Project;
 import boosters.fundboost.project.dto.response.ProjectPreviewResponse;
-import boosters.fundboost.user.converter.UserMyPageConverter;
+import boosters.fundboost.user.converter.MyPageConverter;
 import boosters.fundboost.user.domain.User;
 import boosters.fundboost.user.dto.request.ProfileEditRequest;
+import boosters.fundboost.user.dto.response.PeerMyPageResponse;
 import boosters.fundboost.user.dto.response.UserMyPageResponse;
 import boosters.fundboost.user.exception.UserException;
 import boosters.fundboost.user.repository.UserRepository;
@@ -71,5 +73,18 @@ public class UserServiceImpl implements UserService {
                 .orElse(null);
 
         user.updateUser(request, imageUrl);
+    }
+
+    @Override
+    public PeerMyPageResponse getPeerProfile(Long peerId, Long userId) {
+        MyPageValidator.validatePeerId(peerId, userId);
+
+        User user = userRepository.findById(peerId)
+                .orElseThrow(() -> new UserException(ErrorStatus.USER_NOT_FOUND));
+
+        long followingCount = followService.getFollowingCount(user);
+        long followerCount = followService.getFollowerCount(user);
+
+        return MyPageConverter.toPeerMyPageResponse(user, followingCount, followerCount);
     }
 }

--- a/src/main/java/boosters/fundboost/user/service/UserServiceImpl.java
+++ b/src/main/java/boosters/fundboost/user/service/UserServiceImpl.java
@@ -76,7 +76,7 @@ public class UserServiceImpl implements UserService {
     }
 
     @Override
-    public PeerMyPageResponse getPeerProfile(Long peerId, Long userId) {
+    public PeerMyPageResponse getPeerProfile(Long peerId, Long userId){
         MyPageValidator.validatePeerId(peerId, userId);
 
         User user = userRepository.findById(peerId)

--- a/src/main/java/boosters/fundboost/user/service/UserServiceImpl.java
+++ b/src/main/java/boosters/fundboost/user/service/UserServiceImpl.java
@@ -43,7 +43,7 @@ public class UserServiceImpl implements UserService {
     public UserMyPageResponse getMyPage(User user) {
         long followingCount = followService.getFollowingCount(user);
         long followerCount = followService.getFollowerCount(user);
-        return UserMyPageConverter.toUserMyPageResponse(user, followingCount, followerCount);
+        return MyPageConverter.toUserMyPageResponse(user, followingCount, followerCount);
     }
 
     @Override


### PR DESCRIPTION
### 📍 PR 타입
- [X] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [X] 기타 사소한 수정

### ❗️ 관련 이슈 링크
Close #72

### 🔁 변경 및 추가사항
- 기존 `@AuthUser`는 유저의 검증여부를 판단하고 null이거나 익명의 유저인 경우 예외를 발생시켰습니다.
상대의 마이페이지를 조회할 경우 익명의 유저도 접근이 가능해야하기 때문에 `AuthInfoArgumentResolver` 리졸버를 생성해 등록해뒀습니다.-> `@AuthInfo` 커스텀 어노테이션으로 사용 가능합니다. 

### 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들

### ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] 불필요한 코드는 삭제했어요.
